### PR TITLE
fix: replace unsupported git urls for https

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "homepage": "https://github.com/xavierha/localize-with-spreadsheet",
     "repository": {
         "type": "git",
-        "url": "git://github.com/xavierha/localize-with-spreadsheet.git"
+        "url": "https://github.com/xavierha/localize-with-spreadsheet.git"
     },
     "main": "index.js",
     "dependencies": {
-        "google-spreadsheets": "git://github.com/theoephraim/node-google-spreadsheets.git",
+        "google-spreadsheets": "https://github.com/theoephraim/node-google-spreadsheets.git",
         "q": "0.9.2",
         "mkpath": "0.1.0"
     },


### PR DESCRIPTION
GitHub [stopped accepting](https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git) requests using the `git` protocol on January 11 2022